### PR TITLE
Fix init-project: include test-plan issue runbook + helper

### DIFF
--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -86,7 +86,7 @@ HIGH_RISK="${HIGH_RISK:-none}"
 echo -e "${BLUE}Creating project structure...${NC}"
 
 # Core directories
-mkdir -p intent/features intent/bugs intent/tech-debt workflow-state architecture do-not-repeat drift roadmap scripts golden-data src tests .cursor/rules .cursor/commands .github/workflows
+mkdir -p intent/features intent/bugs intent/tech-debt workflow-state architecture do-not-repeat drift roadmap scripts behaviors golden-data src tests .cursor/rules .cursor/commands .github/workflows
 
 # Copy framework commands, rules, and core scripts into the new project
 if [ -d "$ROOT_DIR/.cursor/commands" ]; then
@@ -113,6 +113,17 @@ for script in new-intent.sh scope-project.sh generate-roadmap.sh generate-releas
         chmod +x "scripts/$script"
     fi
 done
+
+# Copy test-plan issue helper into the new project (used by test runner rules).
+if [ -f "$ROOT_DIR/scripts/create-test-plan-issue.sh" ]; then
+    cp "$ROOT_DIR/scripts/create-test-plan-issue.sh" "scripts/create-test-plan-issue.sh"
+    chmod +x "scripts/create-test-plan-issue.sh"
+fi
+
+# Copy test-plan issue tracking runbook into the new project (referenced by tests + Cursor rules).
+if [ -f "$ROOT_DIR/behaviors/WORK_TEST_PLAN_ISSUES.md" ]; then
+    cp "$ROOT_DIR/behaviors/WORK_TEST_PLAN_ISSUES.md" "behaviors/WORK_TEST_PLAN_ISSUES.md"
+fi
 
 # Create project.json
 cat > project.json << EOF || error_exit "Failed to create project.json"


### PR DESCRIPTION
Resolves #8.

## Summary
- `scripts/init-project.sh` now copies:
  - `behaviors/WORK_TEST_PLAN_ISSUES.md`
  - `scripts/create-test-plan-issue.sh`
  into generated projects.

This makes the docs/rules that reference the runbook and helper valid inside `./projects/shipit-test`.

## Validation
- Generated a fresh project and verified both files exist:
  - `projects/shipit-test-issue8/behaviors/WORK_TEST_PLAN_ISSUES.md`
  - `projects/shipit-test-issue8/scripts/create-test-plan-issue.sh`
- Local: `pnpm test`
- Local: `pnpm lint && pnpm typecheck`

Made with [Cursor](https://cursor.com)