### PR TITLE
Docs: clarify test-run step counts

### DIFF
--- a/.cursor/commands/test_shipit.md
+++ b/.cursor/commands/test_shipit.md
@@ -165,7 +165,11 @@ Output summary:
 ## Test Run Complete
 
 **Date:** [ISO timestamp]
-**Steps Passed:** X/Y
+**Steps Total:** X
+**Steps Executed:** Y
+**Steps Skipped:** Z
+**Steps Passed:** A
+**Steps Failed:** B
 **Blocking Issues:** N
 **Result:** PASS | FAIL
 

--- a/.cursor/rules/test-runner.mdc
+++ b/.cursor/rules/test-runner.mdc
@@ -150,15 +150,22 @@ After completing (or stopping), output:
 
 **Date:** [ISO timestamp]
 **Mode:** [root-project | test-project]
-**Steps Executed:** X
-**Steps Passed:** Y
-**Steps Failed:** Z
+**Steps Total:** X
+**Steps Executed:** Y
+**Steps Skipped:** Z
+**Steps Passed:** A
+**Steps Failed:** B
 **Blocking Issues:** N
 
 **Result:** [PASS if no failures | FAIL if any failures]
 
 See tests/ISSUES.md for details.
 ```
+
+Definitions:
+- **Steps Total**: total steps in scope for the run (including skipped).
+- **Steps Executed**: count of **✅ PASS** + **❌ FAIL** (exclude **⏭️ SKIP**).
+- **Steps Skipped**: count of **⏭️ SKIP**.
 
 ## Run Logging Rules
 

--- a/behaviors/WORK_TEST_PLAN_ISSUES.md
+++ b/behaviors/WORK_TEST_PLAN_ISSUES.md
@@ -174,7 +174,9 @@ Record each test run execution in `tests/ISSUES.md` (**run logs only**, not issu
 
 ### Run: YYYY-MM-DDTHH:MM:SSZ (root-project | test-project)
 
+**Steps Total:** [number]
 **Steps Executed:** [number]
+**Steps Skipped:** [number]
 **Steps Passed:** [number]
 **Steps Failed:** [number]
 **Blocking Issues:** [number]
@@ -193,6 +195,12 @@ Record each test run execution in `tests/ISSUES.md` (**run logs only**, not issu
 ```
 
 **Note:** Issues are tracked on GitHub. Only reference GitHub issue numbers here.
+
+Definitions:
+
+- **Steps Total**: Total steps in the test plan section being run (including those that may be skipped due to blocking failures).
+- **Steps Executed**: Count of steps with status **✅ PASS** or **❌ FAIL** (exclude **⏭️ SKIP**).
+- **Steps Skipped**: Count of steps with status **⏭️ SKIP**.
 
 ---
 

--- a/tests/ISSUES.md
+++ b/tests/ISSUES.md
@@ -2,6 +2,12 @@
 
 This file logs **test runs only**. Issues discovered during runs are tracked on GitHub (see `behaviors/WORK_TEST_PLAN_ISSUES.md`).
 
+## Counting Conventions
+
+- **Steps Executed**: count of steps with status **✅ PASS** or **❌ FAIL** (exclude **⏭️ SKIP**).
+- **Steps Skipped**: count of steps with status **⏭️ SKIP**.
+- **Steps Total**: Steps Executed + Steps Skipped.
+
 ## Test Runs
 
 ### Run: 2026-01-23T23:57:01Z (test-project)


### PR DESCRIPTION
Resolves #9.

## Summary
- Define and standardize test run count semantics:
  - Steps Total
  - Steps Executed (PASS/FAIL only)
  - Steps Skipped (SKIP only)
- Update templates/guidance in:
  - `behaviors/WORK_TEST_PLAN_ISSUES.md`
  - `.cursor/rules/test-runner.mdc`
  - `.cursor/commands/test_shipit.md`
  - `tests/ISSUES.md`

## Validation
- `pnpm test`
- `pnpm lint && pnpm typecheck`

Made with [Cursor](https://cursor.com)