### PR TITLE
docs: add projects/README.md (Resolves #36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ worktrees.json
 .agent-id
 projects/*
 !projects/.gitkeep
+!projects/README.md
 .stryker-tmp

--- a/DIRECTORY_STRUCTURE.md
+++ b/DIRECTORY_STRUCTURE.md
@@ -20,7 +20,7 @@ Quick reference for ShipIt project layout. **Authoritative source:** [architectu
 | `behaviors/`      | Release procedures, issue tracking rules, platform work                                                                                                   |
 | `reports/`        | Generated reports (mutation/, etc.)                                                                                                                       |
 | `golden-data/`    | Replay validation test data                                                                                                                               |
-| `projects/`       | Initialized projects (gitignored except .gitkeep)                                                                                                         |
+| `projects/`       | Initialized ShipIt projects (from /init-project). See [projects/README.md](./projects/README.md). Contents gitignored except .gitkeep.                    |
 | `drift/`          | Baselines and metrics for entropy monitoring                                                                                                              |
 | `.cursor/`        | commands/, rules/, agents/ (Cursor config)                                                                                                                |
 

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,15 @@
+# projects/
+
+Stores initialized ShipIt projects created via `/init-project`.
+
+## Structure
+
+Each subdirectory is a separate project (e.g. `projects/my-app/`). The framework's `init-project` command creates projects here.
+
+## Gitignore
+
+Contents are ignored (except `.gitkeep`) so project files are not committed to the framework repo. Only `.gitkeep` and this README are versioned.
+
+## Usage
+
+Run `/init-project` (or `pnpm init-project` via the init-project script) to create a new project. Open the created directory as its own Cursor workspace to work on it.


### PR DESCRIPTION
Resolves #36

## Summary
Document the purpose of the `projects/` directory (stores initialized ShipIt projects from /init-project).

## Changes
- **projects/README.md** (new): Purpose, structure, gitignore behavior, usage
- **.gitignore**: Add `!projects/README.md` so README is tracked
- **DIRECTORY_STRUCTURE.md**: Reference projects/README.md

## Validation
- `pnpm test` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅

Made with [Cursor](https://cursor.com)