### PR TITLE
Unify 04_verification.md vs 04_security.md (Resolves #25)

### DIFF
--- a/.cursor/commands/risk.md
+++ b/.cursor/commands/risk.md
@@ -23,7 +23,7 @@ Performs a structured security skim and records findings.
 
 ## Output
 
-Writes `workflow-state/04_security.md` with:
+Writes `workflow-state/04_verification.md` (Security section within it) with:
 
 - Threat model summary
 - Findings (if any)
@@ -35,7 +35,7 @@ Writes `workflow-state/04_security.md` with:
 1. Read the intent and plan to identify high-risk domains.
 2. Review for auth/input validation/secrets/PII concerns.
 3. Run dependency audit if applicable: `pnpm audit --audit-level=high`.
-4. Record findings and required mitigations in `workflow-state/04_security.md`.
+4. Record findings and required mitigations in `workflow-state/04_verification.md`.
 
 ## Template
 

--- a/.cursor/rules/security.mdc
+++ b/.cursor/rules/security.mdc
@@ -2,7 +2,7 @@
 description: Security Agent - Threat modeling, attack surface review, red team
 globs:
   - "src/**"
-  - "workflow-state/04_security.md"
+  - "workflow-state/04_verification.md"
 alwaysApply: false
 ---
 
@@ -50,7 +50,7 @@ These domains ALWAYS require human review:
 
 ## Output Format
 
-Save to `workflow-state/04_security.md`:
+Save to `workflow-state/04_verification.md` (Security's section lives in this file alongside QA results; it is the canonical verification artifact for the pipeline):
 
 ```markdown
 # Security Review: F-###: Title

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -247,7 +247,7 @@ show_command_help() {
             echo ""
             echo "Usage: /risk <intent-id>"
             echo ""
-            echo "Writes workflow-state/04_security.md"
+            echo "Writes workflow-state/04_verification.md (Security section)"
             ;;
         revert-plan|revert_plan)
             echo -e "${BLUE}/revert-plan${NC}"


### PR DESCRIPTION
## Summary

Security agent and `/risk` now read/write `workflow-state/04_verification.md` (the same file the rest of the pipeline uses). The duplicate `04_security.md` reference is removed so the Security agent's output is consumed by the workflow.

## Changes

- **.cursor/rules/security.mdc:** Glob and output instructions point to `04_verification.md`; note added that Security's section lives in that file alongside QA results.
- **.cursor/commands/risk.md:** Output and step 4 updated to write to `04_verification.md` (Security section within it).
- **scripts/help.sh:** `/risk` help text updated to say the command writes `04_verification.md` (Security section).

## Validation

- `pnpm test` — 5 tests passed
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- No remaining references to `04_security.md` in codebase

Resolves #25