### PR TITLE
Document behaviors/ in README project structure (Resolves #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ All commands are available as Cursor slash commands. See [`.cursor/commands/`](.
 │   ├── dependencies.md  # Generated dependency graph
 │   └── confidence-calibration.json
 ├── architecture/        # CANON.md (boundaries) + invariants.yml
+├── behaviors/          # Procedures and policies (release, issue tracking, platform work)
 ├── do-not-repeat/      # Failed approaches (don't rediscover)
 ├── drift/              # Entropy monitoring
 └── roadmap/            # now.md, next.md, later.md


### PR DESCRIPTION
## Summary

Add `behaviors/` to the README Project Structure tree so it is visible alongside other key directories. AGENTS.md and architecture/CANON.md already document it; README was the only gap.

## Changes

- **README.md:** One line in the project structure tree: `behaviors/` — Procedures and policies (release, issue tracking, platform work).

## Validation

- `pnpm test` — 5 tests passed.
- Docs only; no code changes.

Resolves #27