### PR TITLE
Add pnpm fix and document commands-scripts contract (Resolves #28)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,12 @@ Humans intervene **ONLY** at these gates:
 | `/kill`        | Kill an intent with rationale       |
 | `/drift_check` | Calculate drift metrics             |
 
+### Commands and scripts
+
+- **Slash command files** live in `.cursor/commands/` and use **underscores** in filenames (e.g. `init_project.md`, `drift_check.md`).
+- **Executable scripts** live in `scripts/` and use **hyphens** (e.g. `init-project.sh`, `fix-intents.sh`).
+- Prefer **`pnpm run <script>`** when a script exists: pnpm script names use hyphens. Examples: `/fix` → `pnpm fix`, `/help` → `pnpm help`, `/verify` → `pnpm verify`, `/drift_check` → `pnpm drift-check`, `/new_intent` → `pnpm new-intent`. See `package.json` scripts for the full list.
+
 ## Truth Hierarchy
 
 When facts conflict, agents MUST know which source wins. This prevents 30–40% of "AI confusion" bugs.

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Entries are automatically appended during `/verify` when outcomes are determined
 
 **Note:** All commands show context-aware next-step suggestions after completion. Scripts auto-verify outputs and run dependent generators (e.g., `/scope-project` automatically runs `/generate-release-plan` and `/generate-roadmap`).
 
-All commands are available as Cursor slash commands. See [`.cursor/commands/`](./.cursor/commands/) for full documentation.
+All commands are available as Cursor slash commands. See [`.cursor/commands/`](./.cursor/commands/) for full documentation. From the CLI, use `pnpm run <script>` where available (e.g. `pnpm fix`, `pnpm help`, `pnpm verify`); see [AGENTS.md](./AGENTS.md) for the commands–scripts mapping.
 
 ## Example: Ship a Feature
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "build": "tsc",
     "drift-check": "./scripts/drift-check.sh",
+    "fix": "./scripts/fix-intents.sh",
     "new-intent": "./scripts/new-intent.sh",
     "init-project": "./scripts/init-project.sh",
     "scope-project": "./scripts/scope-project.sh",


### PR DESCRIPTION
## Summary

- Add `pnpm fix` that runs `scripts/fix-intents.sh` so agents and users can run `/fix` via the CLI.
- Document the commands–scripts contract in AGENTS.md (command files use underscores, scripts use hyphens; prefer `pnpm run <script>`).
- Add a one-sentence pointer in README for CLI usage and the mapping.

## Changes

- **package.json:** New script `"fix": "./scripts/fix-intents.sh"`.
- **AGENTS.md:** New subsection "Commands and scripts" under Slash Commands (naming convention + pnpm mapping examples).
- **README.md:** Sentence added: use `pnpm run <script>` from CLI; see AGENTS.md for mapping.

## Validation

- `pnpm test` — 5 tests passed.
- `pnpm fix` runs and invokes fix-intents.sh.

Resolves #28