### PR TITLE
Move agent-coordinator and queue/status to experimental/ (Resolves #29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ projects/*
 !projects/README.md
 .stryker-tmp
 
+# Experimental coordinator state (generated in experimental/)
+experimental/agent-queue.json
+experimental/agent-status.json
+
 # Scratch files from agent workflows (issue creation, resolution notes, release planning)
 .gh-*.md
 .resolution-*.md

--- a/README.md
+++ b/README.md
@@ -338,7 +338,8 @@ All commands are available as Cursor slash commands. See [`.cursor/commands/`](.
 ├── behaviors/          # Procedures and policies (release, issue tracking, platform work)
 ├── do-not-repeat/      # Failed approaches (don't rediscover)
 ├── drift/              # Entropy monitoring
-└── roadmap/            # now.md, next.md, later.md
+├── roadmap/            # now.md, next.md, later.md
+└── experimental/       # Experimental tooling (e.g. agent-coordinator); not part of main workflow
 ```
 
 ### Planning outputs

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,0 +1,5 @@
+# Experimental
+
+Tooling and artifacts that are **not part of the main ShipIt workflow**. Use at your own discretion; they may change or be removed.
+
+- **agent-coordinator.sh** — Task queue and agent assignment. Writes `agent-queue.json` and `agent-status.json` in this directory. Schemas: `agent-queue-schema.json`, `agent-status-schema.json`. Not referenced by core scripts or documented in the main project structure.

--- a/experimental/agent-queue-schema.json
+++ b/experimental/agent-queue-schema.json
@@ -32,7 +32,14 @@
           },
           "type": {
             "type": "string",
-            "enum": ["analysis", "planning", "test-writing", "implementation", "verification", "documentation"],
+            "enum": [
+              "analysis",
+              "planning",
+              "test-writing",
+              "implementation",
+              "verification",
+              "documentation"
+            ],
             "description": "Task type (SDLC phase)"
           },
           "status": {
@@ -63,12 +70,12 @@
           },
           "dependencies": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": { "type": "string" },
             "description": "Task IDs that must complete before this task"
           },
           "conflicts": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": { "type": "string" },
             "description": "Task IDs that conflict with this task"
           },
           "estimatedDuration": {
@@ -81,7 +88,7 @@
           },
           "outputFiles": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": { "type": "string" },
             "description": "Files created/modified by this task"
           },
           "notes": {

--- a/experimental/agent-status-schema.json
+++ b/experimental/agent-status-schema.json
@@ -67,9 +67,9 @@
                   "type": "string",
                   "enum": ["request", "response", "notification", "conflict"]
                 },
-                "from": {"type": "string"},
-                "to": {"type": "string"},
-                "message": {"type": "string"}
+                "from": { "type": "string" },
+                "to": { "type": "string" },
+                "message": { "type": "string" }
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "check-readiness": "./scripts/check-readiness.sh",
     "deploy": "./scripts/deploy.sh",
     "generate-docs": "./scripts/generate-docs.sh",
-    "agent-coordinator": "./scripts/agent-coordinator.sh",
+    "agent-coordinator": "./experimental/agent-coordinator.sh",
     "workflow-orchestrator": "./scripts/workflow-orchestrator.sh",
     "kill-intent": "./scripts/kill-intent.sh",
     "verify": "./scripts/verify.sh",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,8 @@ Shell scripts for the ShipIt framework. Run via `pnpm <script-name>` (see `packa
 
 - `workflow-orchestrator.sh` — Generate workflow state files for `/ship` phases
 - `verify.sh` — Run verification phase (tests, mutation, audit)
-- `agent-coordinator.sh` — Manage task queue and agent assignment
+
+Agent coordinator (task queue and agent assignment) is **experimental** and lives in `experimental/`; see `experimental/README.md`.
 
 ### Generation
 

--- a/scripts/setup-worktrees.sh
+++ b/scripts/setup-worktrees.sh
@@ -74,7 +74,7 @@ for i in $(seq 1 $TASK_COUNT); do
   fi
   
   # Register agent in coordination system
-  if [ -f "scripts/agent-coordinator.sh" ]; then
+  if [ -f "experimental/agent-coordinator.sh" ]; then
     AGENT_ID="agent-$i"
     # Agent will be registered when first task is assigned
   fi

--- a/scripts/validate-cursor.sh
+++ b/scripts/validate-cursor.sh
@@ -90,7 +90,7 @@ echo ""
 
 # Check 5: Scripts are executable
 echo -e "${YELLOW}[5/6] Checking script executability...${NC}"
-SCRIPTS=("init-project.sh" "scope-project.sh" "deploy.sh" "agent-coordinator.sh" "workflow-orchestrator.sh")
+SCRIPTS=("init-project.sh" "scope-project.sh" "deploy.sh" "workflow-orchestrator.sh")
 MISSING=0
 for script in "${SCRIPTS[@]}"; do
     if [ -f "scripts/$script" ] && [ -x "scripts/$script" ]; then


### PR DESCRIPTION
## Summary

Treat agent-coordinator and queue/status JSON as **experimental**. Move script and schemas to `experimental/`; script writes queue and status files there so repo root is unused. Document in experimental/README and README project structure.

## Changes

- **experimental/:** New directory with README. `agent-coordinator.sh` (writes to script dir), `agent-queue-schema.json`, `agent-status-schema.json` moved here.
- **package.json:** agent-coordinator script path → `./experimental/agent-coordinator.sh`.
- **scripts/setup-worktrees.sh:** Path check → `experimental/agent-coordinator.sh`.
- **scripts/validate-cursor.sh:** Removed agent-coordinator from core scripts list.
- **scripts/README.md:** Note that coordinator is in experimental/.
- **README.md:** experimental/ in project structure.
- **.gitignore:** Ignore experimental/agent-queue.json and agent-status.json.

## Validation

- `pnpm test` — 5 tests passed.
- `pnpm agent-coordinator init` — creates files in experimental/.

Resolves #29