### PR TITLE
feat(scripts): add common.sh and intent.sh libs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,6 +60,8 @@ Agent coordinator (task queue and agent assignment) is **experimental** and live
 
 ## Shared Libraries (`lib/`)
 
+- `common.sh` — Plumbing: `error_exit`, color variables, optional `require_cmd`. Source this (or `intent.sh`) in new scripts to avoid duplicating error handling and colors.
+- `intent.sh` — Intent domain: `resolve_intent_file`, `require_intent_file`, `INTENT_DIR`. Sources `common.sh`. Use in scripts that resolve intent IDs to paths (e.g. workflow-orchestrator, kill-intent).
 - `progress.sh` — Progress indicator helpers
 - `suggest-next.sh` — Next-step suggestion logic
 - `validate-intents.sh` — Intent validation (dependencies, circular deps)

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Common script plumbing: error handling, colors, optional require_* helpers.
+# Source this from scripts that need consistent exit behavior and colors.
+# For intent resolution, source intent.sh instead (it sources this).
+# Caller script should already use set -euo pipefail.
+
+error_exit() {
+    echo "ERROR: $1" >&2
+    exit "${2:-1}"
+}
+
+# Colors (safe to use in echo -e)
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Optional: require a command to be present. Usage: require_cmd node jq git
+require_cmd() {
+    local cmd
+    for cmd in "$@"; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            error_exit "$cmd is required but not installed" 1
+        fi
+    done
+}

--- a/scripts/lib/intent.sh
+++ b/scripts/lib/intent.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Intent domain helpers: resolve intent file path, require intent file.
+# Sources common.sh. Use this in scripts that work with intent IDs (e.g. workflow-orchestrator, kill-intent).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+[ -f "$SCRIPT_DIR/common.sh" ] && source "$SCRIPT_DIR/common.sh"
+
+INTENT_DIR="${INTENT_DIR:-work/intent}"
+
+# Resolve an intent ID (e.g. F-042) or path to the actual intent file path.
+# Outputs the path; returns 0 if found, 1 if not. Use with require_intent_file to exit on failure.
+resolve_intent_file() {
+    local intent_id="$1"
+
+    if [ -f "$intent_id" ]; then
+        echo "$intent_id"
+        return 0
+    fi
+
+    local candidates=(
+        "work/intent/$intent_id.md"
+        "work/intent/features/$intent_id.md"
+        "work/intent/bugs/$intent_id.md"
+        "work/intent/tech-debt/$intent_id.md"
+    )
+
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        if [ -f "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    local matches=()
+    shopt -s nullglob
+    matches=( work/intent/*/"$intent_id".md )
+    shopt -u nullglob
+
+    if [ "${#matches[@]}" -eq 1 ]; then
+        echo "${matches[0]}"
+        return 0
+    fi
+
+    if [ "${#matches[@]}" -gt 1 ]; then
+        error_exit "Multiple intent files found for $intent_id: ${matches[*]}" 1
+    fi
+
+    return 1
+}
+
+# Resolve intent and exit with error if not found. Sets INTENT_FILE in caller.
+# Usage: INTENT_FILE="$(require_intent_file "$INTENT_ID")"
+require_intent_file() {
+    local intent_id="$1"
+    local path
+    path="$(resolve_intent_file "$intent_id")" || error_exit "Intent file not found for id '$intent_id' (looked under work/intent/ and work/intent/*/)" 1
+    echo "$path"
+}

--- a/scripts/workflow-orchestrator.sh
+++ b/scripts/workflow-orchestrator.sh
@@ -5,73 +5,21 @@
 
 set -euo pipefail
 
-error_exit() {
-    echo "ERROR: $1" >&2
-    exit "${2:-1}"
-}
-
-# Colors
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-RED='\033[0;31m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/intent.sh
+[ -f "$SCRIPT_DIR/lib/intent.sh" ] && source "$SCRIPT_DIR/lib/intent.sh"
 
 INTENT_ID="${1:-}"
 if [ -z "$INTENT_ID" ]; then
     error_exit "Usage: $0 <intent-id>" 1
 fi
 
-resolve_intent_file() {
-    local intent_id="$1"
-
-    # If the caller passed a direct path, respect it.
-    if [ -f "$intent_id" ]; then
-        echo "$intent_id"
-        return 0
-    fi
-
-    # Common/expected locations (init-project + new-intent + scope-project write to subfolders).
-    local candidates=(
-        "work/intent/$intent_id.md"
-        "work/intent/features/$intent_id.md"
-        "work/intent/bugs/$intent_id.md"
-        "work/intent/tech-debt/$intent_id.md"
-    )
-
-    local candidate=""
-    for candidate in "${candidates[@]}"; do
-        if [ -f "$candidate" ]; then
-            echo "$candidate"
-            return 0
-        fi
-    done
-
-    # Fallback: search one level deep under intent/ (portable; no find/globstar needed).
-    local matches=()
-    shopt -s nullglob
-    matches=( work/intent/*/"$intent_id".md )
-    shopt -u nullglob
-
-    if [ "${#matches[@]}" -eq 1 ]; then
-        echo "${matches[0]}"
-        return 0
-    fi
-
-    if [ "${#matches[@]}" -gt 1 ]; then
-        error_exit "Multiple intent files found for $intent_id: ${matches[*]}" 1
-    fi
-
-    return 1
-}
-
-INTENT_FILE="$(resolve_intent_file "$INTENT_ID")" || error_exit "Intent file not found for id '$INTENT_ID' (looked under work/intent/ and work/intent/*/)" 1
+INTENT_FILE="$(require_intent_file "$INTENT_ID")"
 
 WORKFLOW_DIR="work/workflow-state"
 mkdir -p "$WORKFLOW_DIR"
 
 # Source progress library
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ -f "$SCRIPT_DIR/lib/progress.sh" ]; then
     source "$SCRIPT_DIR/lib/progress.sh"
 fi


### PR DESCRIPTION
Resolves #53

**Summary**
- Add `scripts/lib/common.sh`: `error_exit`, colors, optional `require_cmd`
- Add `scripts/lib/intent.sh`: `resolve_intent_file`, `require_intent_file`, `INTENT_DIR`; sources common.sh
- Migrate `workflow-orchestrator.sh` and `kill-intent.sh` to use the libs (remove duplicated logic)
- Document in scripts/README.md

**Validation**
- Orchestrator and kill-intent usage/not-found errors behave as before
- `pnpm test` passes