### PR TITLE
feat(scripts): add command manifest for slash commands

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,7 +50,8 @@ Agent coordinator (task queue and agent assignment) is **experimental** and live
 
 ### Utilities
 
-- `help.sh` — List all commands with descriptions
+- `help.sh` — List all commands with descriptions (builds "Available commands" from `command-manifest.yml`)
+- `command-manifest.yml` — Single source of truth for slash commands: id, slash, pnpm script, one-liner, category. Add a command by adding an entry; help.sh reads it.
 - `status.sh` — Unified dashboard (intents, workflow, tests)
 - `suggest.sh` — Suggest next intent to work on
 

--- a/scripts/command-manifest.yml
+++ b/scripts/command-manifest.yml
@@ -1,0 +1,96 @@
+# Command manifest: single source of truth for slash commands and pnpm scripts.
+# help.sh builds the "Available commands" list from this file.
+# Add a command by adding an entry; keep id, slash, pnpm, description, category.
+
+commands:
+  # Project Management
+  - id: init-project
+    slash: /init-project
+    pnpm: init-project
+    description: Initialize a new ShipIt project
+    category: Project Management
+  - id: scope-project
+    slash: /scope-project
+    pnpm: scope-project
+    description: AI-assisted feature breakdown
+    category: Project Management
+
+  # Intent Management
+  - id: new-intent
+    slash: /new_intent
+    pnpm: new-intent
+    description: Create a new intent (interactive wizard)
+    category: Intent Management
+  - id: kill
+    slash: /kill
+    pnpm: kill-intent
+    description: Kill an intent with rationale
+    category: Intent Management
+
+  # Workflow
+  - id: ship
+    slash: /ship
+    pnpm: workflow-orchestrator
+    description: Run full SDLC workflow (6 phases)
+    category: Workflow
+  - id: verify
+    slash: /verify
+    pnpm: verify
+    description: Re-run verification phase
+    category: Workflow
+
+  # Planning
+  - id: generate-release-plan
+    slash: /generate-release-plan
+    pnpm: generate-release-plan
+    description: Build release plan from intents
+    category: Planning
+  - id: generate-roadmap
+    slash: /generate-roadmap
+    pnpm: generate-roadmap
+    description: Generate roadmap (now/next/later)
+    category: Planning
+
+  # Operations
+  - id: deploy
+    slash: /deploy
+    pnpm: deploy
+    description: Deploy with readiness checks
+    category: Operations
+  - id: drift-check
+    slash: /drift_check
+    pnpm: drift-check
+    description: Check for entropy/decay
+    category: Operations
+  - id: risk
+    slash: /risk
+    pnpm: null
+    description: Force security/threat skim
+    category: Operations
+
+  # Help & Status
+  - id: help
+    slash: /help
+    pnpm: help
+    description: Show help for a command
+    category: Help & Status
+  - id: status
+    slash: /status
+    pnpm: status
+    description: Show current project status
+    category: Help & Status
+  - id: suggest
+    slash: /suggest
+    pnpm: suggest
+    description: Get suggested next actions
+    category: Help & Status
+  - id: pr
+    slash: /pr
+    pnpm: null
+    description: Generate PR summary/checklist
+    category: Help & Status
+  - id: revert-plan
+    slash: /revert-plan
+    pnpm: null
+    description: Write rollback plan
+    category: Help & Status


### PR DESCRIPTION
Resolves #55

**Summary**
- Add scripts/command-manifest.yml (id, slash, pnpm, description, category) for all user-facing commands
- help.sh builds "Available commands" from manifest; long-form help unchanged
- Document manifest in scripts/README.md

**Validation**
- pnpm run help and pnpm run help ship work; pnpm test passes