### PR TITLE
feat: headless/CLI and VS Code docs — Resolves #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Entries are automatically appended during `/verify` when outcomes are determined
 | `/rollback <id>` | Execute rollback in guided mode (reads plan from /revert-plan)                               | When reverting shipped work       |
 | `/kill <id>`     | Kill an intent (with rationale)                                                              | When work should stop permanently |
 
+**Headless / VS Code:** You can run the same workflow from the CLI or VS Code terminal. Set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` and run `pnpm headless-run-phase <intent-id> <phase>` (phases 1–5). Human approval is required after phase 2 (plan) and phase 5 (release). See [Headless mode](docs/headless-mode.md) and [Using ShipIt in VS Code](docs/vscode-usage.md).
+
 ### Maintenance
 
 | Command         | What It Does                                        | When to Use                    |

--- a/docs/headless-mode.md
+++ b/docs/headless-mode.md
@@ -1,0 +1,77 @@
+# Headless Mode (Running ShipIt Outside Cursor)
+
+This doc describes how to run the ShipIt workflow from the **CLI** (or from VS Code terminal) without Cursor slash commands. The same phases, artifacts, and rules apply; only the **invocation** differs (script + LLM API instead of Cursor chat).
+
+## What "running ShipIt outside Cursor" means
+
+- **Same workflow:** Analysis → Planning → Implementation → Verification → Release. Same `work/workflow-state/` files and `.cursor/commands` / `.cursor/rules` content.
+- **Headless runner:** A script (`scripts/headless/run-phase.sh`) reads the same instruction files Cursor uses, builds a prompt, calls an LLM (OpenAI or Anthropic) via API, and writes the model output to the appropriate workflow-state file.
+- **Human gates:** Some phases require human approval before continuing. The runner stops at those points and tells you how to approve and resume.
+
+## Phases that can run headless
+
+| Phase | Name           | Runs headless? | Human gate after?                |
+| ----- | -------------- | -------------- | -------------------------------- |
+| 1     | Analysis       | Yes            | No                               |
+| 2     | Planning       | Yes            | **Yes — plan approval**          |
+| 3     | Implementation | Yes            | No                               |
+| 4     | Verification   | Yes            | No                               |
+| 5     | Release        | Yes            | **Yes — Steward final approval** |
+
+- **After Phase 2:** You must review `work/workflow-state/<intent-id>/02_plan.md` (or flat `work/workflow-state/02_plan.md`) and signal approval before the runner continues to implementation. Add `APPROVED` or check the approval box in the plan file, or run a script that records approval.
+- **After Phase 5:** Steward (or human) approves release. Same idea: approve in the release notes or via a documented step, then run the next phase or finish.
+
+## How to run headless
+
+### Prerequisites
+
+- **API key:** Set one of:
+  - `OPENAI_API_KEY` — for OpenAI (e.g. GPT-4)
+  - `ANTHROPIC_API_KEY` — for Anthropic (e.g. Claude)
+- **Secrets:** Never commit API keys. Use env vars or a secure secret manager. Standard names above so scripts and docs stay in sync.
+- **Repo layout:** Run from the ShipIt repo root. Same `work/`, `_system/`, `.cursor/` layout as Cursor; headless reads from `.cursor/commands/` and `.cursor/rules/`.
+
+### Running one phase
+
+```bash
+# From repo root
+./scripts/headless/run-phase.sh <intent-id> <phase-number>
+```
+
+Example: `./scripts/headless/run-phase.sh F-001 1` runs Phase 1 (Analysis) for intent F-001. The script:
+
+1. Resolves workflow state dir (flat or per-intent; see [workflow-state-layout.md](../_system/architecture/workflow-state-layout.md)). For multi-intent layout, intent-id is required.
+2. Reads phase instructions from `.cursor/commands/ship.md` and the role rule from `.cursor/rules/<role>.mdc`
+3. Builds a prompt and calls the LLM
+4. Writes the model output to the phase output file (e.g. `01_analysis.md`)
+5. If the phase is 2 or 5, prints **Waiting for human approval** and exits; you approve, then run the next phase manually
+
+### After Phase 2 (plan approval)
+
+1. Open `work/workflow-state/02_plan.md` (or `work/workflow-state/<intent-id>/02_plan.md`)
+2. Review the plan and add approval (e.g. add a line `APPROVED` or check the approval checkbox)
+3. Run the next phase: `./scripts/headless/run-phase.sh <intent-id> 3`
+
+### After Phase 5 (release / Steward)
+
+1. Review release notes and any final gates
+2. Approve per your process (edit file or run a script that records approval)
+3. No further headless phase; workflow is complete unless you add automation for the final step
+
+### Running all phases in sequence
+
+There is no single "run all" script that bypasses human gates. Run phases 1 and 2; after you approve the plan, run 3, 4, 5. Optionally wrap in a small script that runs 1→2, prompts you to approve, then runs 3→4→5.
+
+## Single source of instructions
+
+Headless mode **must** read the same `.cursor/commands/` and `.cursor/rules/` files as Cursor. No separate "headless" prompt or phase definition. Phase order and content come from `ship.md` and `scripts/workflow-templates/phases.yml`. Any change to the workflow (e.g. new phase or rule) is in one place and applies to both Cursor and headless.
+
+## Compatibility
+
+- Headless mode is compatible with the same `.cursor/` and workflow-state layout as Cursor. If you upgrade ShipIt, re-run headless from the same repo so command and rule content stay in sync.
+- Do not copy command or rule text into external systems; always read from the repo at runtime.
+
+## Relation to Cursor and VS Code
+
+- **Cursor:** Remains the primary path. Slash commands and rules work as today. Headless is opt-in.
+- **VS Code:** You can run headless scripts from the VS Code terminal. For full VS Code parity (command palette → Copilot with same context as Cursor), see [Using ShipIt in VS Code](vscode-usage.md) and issue #68 (VS Code extension).

--- a/docs/vscode-usage.md
+++ b/docs/vscode-usage.md
@@ -1,0 +1,30 @@
+# Using ShipIt in VS Code
+
+You can use ShipIt from **VS Code** (with GitHub Copilot or another AI assistant) without Cursor. The same artifacts, workflow state, and scripts apply; only how you **invoke** the workflow differs.
+
+## Same layout and scripts
+
+- **Artifacts:** `work/intent/`, `work/workflow-state/`, `_system/`, `.cursor/commands/`, `.cursor/rules/` — all the same. Open the repo in VS Code and run scripts from the integrated terminal.
+- **Scripts:** From repo root, run `pnpm workflow-orchestrator <intent-id>`, `pnpm verify <intent-id>`, `pnpm status`, etc. Same as in Cursor.
+- **Headless mode:** If you want the LLM to run phases without Cursor, use [Headless mode](headless-mode.md) and set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`; run `./scripts/headless/run-phase.sh <intent-id> <phase>` from the terminal.
+
+## Doc-based workflow in VS Code (until the extension exists)
+
+Cursor uses slash commands (e.g. `/ship F-001`) that inject the full command and rule content into chat. In VS Code you don’t have those slash commands by default, but you can get the same instructions into Copilot Chat:
+
+1. **Open the command file** — e.g. `.cursor/commands/ship.md` (or the relevant command).
+2. **Open the role rule** — e.g. `.cursor/rules/pm.mdc` for Phase 1 (Analysis).
+3. **In Copilot Chat**, reference or paste the content: e.g. “Follow the instructions in ship.md for Phase 1 (Analysis). I am the PM. Intent: F-001. Use the PM rule in .cursor/rules/pm.mdc.”
+4. **Run scripts in the terminal** — `pnpm workflow-orchestrator F-001`, then `pnpm verify F-001`, etc.
+
+**Prompt pattern:** Tell the model which phase you’re in, which role (PM, Architect, Implementer, QA, Docs), the intent id, and point it at the command and rule files. Same content as Cursor; you’re just loading it manually or via a snippet.
+
+## Full parity: VS Code extension (#68)
+
+Issue **#68** tracks a **VS Code extension** that will:
+
+- Register ShipIt commands in the Command Palette (e.g. “ShipIt: Ship”, “ShipIt: Verify”).
+- Open Copilot Chat with the **exact same context** Cursor injects for slash commands (command + rule content, intent id).
+- One action in VS Code → same UX as `/ship` in Cursor.
+
+Until that extension exists, use the doc-based flow above or headless mode from the terminal.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "generate-docs": "./scripts/generate-docs.sh",
     "agent-coordinator": "./experimental/agent-coordinator.sh",
     "workflow-orchestrator": "./scripts/workflow-orchestrator.sh",
+    "headless-run-phase": "./scripts/headless/run-phase.sh",
     "kill-intent": "./scripts/kill-intent.sh",
     "verify": "./scripts/verify.sh",
     "execute-rollback": "./scripts/execute-rollback.sh",

--- a/scripts/headless/README.md
+++ b/scripts/headless/README.md
@@ -1,0 +1,8 @@
+# Headless mode scripts
+
+Run ShipIt phases from the CLI without Cursor. Uses the same `.cursor/commands` and `.cursor/rules` as Cursor; calls OpenAI or Anthropic API to generate phase output.
+
+- **run-phase.sh** — Run one phase (1–5) for an intent. Requires `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`.
+- **call-llm.js** — Helper that sends a prompt to the LLM and prints the response (used by run-phase.sh).
+
+See [docs/headless-mode.md](../../docs/headless-mode.md) for full documentation, human gates, and how to approve.

--- a/scripts/headless/call-llm.js
+++ b/scripts/headless/call-llm.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Call OpenAI or Anthropic API with a prompt; print the model response to stdout.
+ * Requires OPENAI_API_KEY or ANTHROPIC_API_KEY. Used by run-phase.sh.
+ * Usage: node scripts/headless/call-llm.js [--prompt "inline prompt"]
+ *   Or: echo "prompt" | node scripts/headless/call-llm.js
+ */
+
+import { readFileSync } from "node:fs";
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+
+function getStdin() {
+  return new Promise((resolve) => {
+    if (process.stdin.isTTY) resolve("");
+    else {
+      const chunks = [];
+      process.stdin.on("data", (chunk) => chunks.push(chunk));
+      process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    }
+  });
+}
+
+async function main() {
+  let prompt = "";
+  const arg = process.argv[2];
+  if (arg === "--prompt" && process.argv[3] != null) {
+    prompt = process.argv[3];
+  } else {
+    prompt = (await getStdin()).trim();
+  }
+  if (!prompt) {
+    console.error("Usage: echo 'prompt' | node call-llm.js   OR   node call-llm.js --prompt 'your prompt'");
+    process.exit(1);
+  }
+
+  if (OPENAI_API_KEY) {
+    const url = "https://api.openai.com/v1/chat/completions";
+    const body = {
+      model: process.env.OPENAI_MODEL || "gpt-4o-mini",
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: 4096,
+    };
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.text();
+      console.error("OpenAI API error:", res.status, err);
+      process.exit(1);
+    }
+    const data = await res.json();
+    const text = data.choices?.[0]?.message?.content ?? "";
+    if (!text) {
+      console.error("OpenAI returned no content:", JSON.stringify(data).slice(0, 200));
+      process.exit(1);
+    }
+    process.stdout.write(text);
+    return;
+  }
+
+  if (ANTHROPIC_API_KEY) {
+    const url = "https://api.anthropic.com/v1/messages";
+    const body = {
+      model: process.env.ANTHROPIC_MODEL || "claude-3-5-haiku-20241022",
+      max_tokens: 4096,
+      messages: [{ role: "user", content: prompt }],
+    };
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": ANTHROPIC_API_KEY,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.text();
+      console.error("Anthropic API error:", res.status, err);
+      process.exit(1);
+    }
+    const data = await res.json();
+    const block = data.content?.find((c) => c.type === "text");
+    const text = block?.text ?? "";
+    if (!text) {
+      console.error("Anthropic returned no text:", JSON.stringify(data).slice(0, 200));
+      process.exit(1);
+    }
+    process.stdout.write(text);
+    return;
+  }
+
+  console.error(
+    "Set OPENAI_API_KEY or ANTHROPIC_API_KEY to run headless. Never commit API keys."
+  );
+  process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/headless/run-phase.sh
+++ b/scripts/headless/run-phase.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Run one ShipIt phase headless (no Cursor). Reads same .cursor/ content, calls LLM, writes state.
+# Usage: ./scripts/headless/run-phase.sh <intent-id> <phase-number>
+# Phase: 1=Analysis, 2=Planning, 3=Implementation, 4=Verification, 5=Release.
+# Requires OPENAI_API_KEY or ANTHROPIC_API_KEY. See docs/headless-mode.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Source libs (use absolute paths so we find them from repo root)
+HELPER_DIR="$SCRIPT_DIR/../lib"
+[ -f "$HELPER_DIR/common.sh" ] && source "$HELPER_DIR/common.sh"
+[ -f "$HELPER_DIR/intent.sh" ] && source "$HELPER_DIR/intent.sh"
+[ -f "$HELPER_DIR/workflow_state.sh" ] && source "$HELPER_DIR/workflow_state.sh"
+
+INTENT_ID="${1:-}"
+PHASE_NUM="${2:-}"
+if [ -z "$INTENT_ID" ] || [ -z "$PHASE_NUM" ]; then
+  echo "Usage: $0 <intent-id> <phase-number>" >&2
+  echo "  Phase: 1=Analysis, 2=Planning, 3=Implementation, 4=Verification, 5=Release" >&2
+  exit 1
+fi
+
+# Require intent file
+require_intent_file "$INTENT_ID" >/dev/null || error_exit "Intent file not found for $INTENT_ID" 1
+
+# Resolve workflow state dir (flat or per-intent)
+WORKFLOW_DIR="$(get_workflow_state_dir "$INTENT_ID")"
+[ -n "$WORKFLOW_DIR" ] || error_exit "No workflow state dir for $INTENT_ID. Run pnpm workflow-orchestrator $INTENT_ID first." 1
+mkdir -p "$WORKFLOW_DIR"
+
+# Phase config: output file, role rule name, phase name
+case "$PHASE_NUM" in
+  1) OUT_FILE="01_analysis.md";   ROLE_RULE="pm";         PHASE_NAME="Analysis (PM)" ;;
+  2) OUT_FILE="02_plan.md";       ROLE_RULE="architect";  PHASE_NAME="Planning (Architect)" ;;
+  3) OUT_FILE="03_implementation.md"; ROLE_RULE="implementer"; PHASE_NAME="Implementation (Implementer)" ;;
+  4) OUT_FILE="04_verification.md"; ROLE_RULE="qa";       PHASE_NAME="Verification (QA)" ;;
+  5) OUT_FILE="05_release_notes.md"; ROLE_RULE="docs";    PHASE_NAME="Release (Docs)" ;;
+  *) error_exit "Phase must be 1-5, got: $PHASE_NUM" 1 ;;
+esac
+
+# Check API key
+if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "Set OPENAI_API_KEY or ANTHROPIC_API_KEY to run headless. Never commit API keys." >&2
+  echo "See docs/headless-mode.md for details." >&2
+  exit 1
+fi
+
+# Read role rule and ship command content (same source as Cursor)
+ROLE_FILE=".cursor/rules/${ROLE_RULE}.mdc"
+SHIP_FILE=".cursor/commands/ship.md"
+[ -f "$ROLE_FILE" ] || error_exit "Role rule not found: $ROLE_FILE" 1
+[ -f "$SHIP_FILE" ] || error_exit "Command file not found: $SHIP_FILE" 1
+
+ROLE_CONTENT="$(cat "$ROLE_FILE")"
+SHIP_CONTENT="$(cat "$SHIP_FILE")"
+
+# Build prompt: single source of instructions
+PROMPT="You are running ShipIt Phase $PHASE_NUM: $PHASE_NAME. Intent ID: $INTENT_ID.
+Write the content for the output file: $OUT_FILE (path under work/workflow-state).
+Do not include the filename or markdown fence in your response; output only the file body.
+
+=== Role and constraints (follow these) ===
+$ROLE_CONTENT
+
+=== Workflow instructions (ship command) ===
+$SHIP_CONTENT
+
+=== Task ===
+Produce the complete content for $OUT_FILE for intent $INTENT_ID. Output only the file body, no preamble."
+
+# Call LLM and write output
+echo "Running Phase $PHASE_NUM ($PHASE_NAME) for $INTENT_ID..." >&2
+node "$SCRIPT_DIR/call-llm.js" --prompt "$PROMPT" > "$WORKFLOW_DIR/$OUT_FILE" || exit 1
+echo "Wrote $WORKFLOW_DIR/$OUT_FILE" >&2
+
+# Human gates: after phase 2 (plan) and phase 5 (release)
+if [ "$PHASE_NUM" = "2" ]; then
+  echo "" >&2
+  echo "*** Waiting for human approval ***" >&2
+  echo "Review $WORKFLOW_DIR/02_plan.md and add APPROVED (or check the approval box)." >&2
+  echo "Then run: $0 $INTENT_ID 3" >&2
+  exit 0
+fi
+if [ "$PHASE_NUM" = "5" ]; then
+  echo "" >&2
+  echo "*** Release phase complete. Steward/human approval may be required. ***" >&2
+  echo "Review $WORKFLOW_DIR/05_release_notes.md. Then run verify or ship as needed." >&2
+  exit 0
+fi
+
+# Next phase hint
+NEXT=$((PHASE_NUM + 1))
+if [ "$NEXT" -le 5 ]; then
+  echo "Next: $0 $INTENT_ID $NEXT" >&2
+fi

--- a/scripts/test-headless.sh
+++ b/scripts/test-headless.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Smoke test for headless mode (issue #65). Ensures run-phase.sh runs and fails cleanly without API keys.
+# With OPENAI_API_KEY or ANTHROPIC_API_KEY set, you can run phase 1 and assert output file exists.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+fail() { echo -e "${RED}FAIL: $*${NC}" >&2; exit 1; }
+ok()   { echo -e "${GREEN}OK: $*${NC}"; }
+
+# Need an intent that exists and has workflow state (or we'll get "run workflow-orchestrator first")
+INTENT_ID="${1:-F-DUMMY}"
+if [ ! -f "work/intent/features/$INTENT_ID.md" ] && [ ! -f "work/intent/$INTENT_ID.md" ]; then
+  # Try to find any intent
+  INTENT_ID=""
+  for f in work/intent/features/*.md work/intent/*.md; do
+    [ -f "$f" ] && INTENT_ID="$(basename "$f" .md)" && break
+  done 2>/dev/null || true
+fi
+[ -n "$INTENT_ID" ] || { echo "Skip: no intent file found (create one or pass intent-id)"; exit 0; }
+
+# 1) Without API keys, run-phase.sh must exit 1 with clear message
+unset OPENAI_API_KEY ANTHROPIC_API_KEY
+out="$(bash scripts/headless/run-phase.sh "$INTENT_ID" 1 2>&1)" || true
+if [ "${#out}" -eq 0 ]; then
+  fail "run-phase.sh should print message when API keys unset"
+fi
+if ! echo "$out" | grep -q "OPENAI_API_KEY\|ANTHROPIC_API_KEY"; then
+  fail "run-phase.sh should mention API key env vars when unset"
+fi
+ok "run-phase.sh exits with clear message when API keys unset"
+
+# 2) Invalid phase number must exit 1
+out2="$(bash scripts/headless/run-phase.sh "$INTENT_ID" 99 2>&1)" || true
+if ! echo "$out2" | grep -q "Phase must be 1-5\|error\|Error"; then
+  fail "run-phase.sh should reject invalid phase number"
+fi
+ok "run-phase.sh rejects invalid phase"
+
+echo ""
+echo -e "${GREEN}Headless smoke test passed.${NC}"


### PR DESCRIPTION
## Summary

Implements **running ShipIt outside Cursor** (issue #65): documented headless scope, CLI phase runner, and VS Code usage docs.

## Changes

- **docs/headless-mode.md** — What headless means; phases 1–5; human gates (after plan and release); how to run and approve; API keys (OPENAI_API_KEY / ANTHROPIC_API_KEY); single source of instructions; compatibility.
- **docs/vscode-usage.md** — Same layout and scripts; doc-based workflow in VS Code; link to #68 for extension.
- **scripts/headless/run-phase.sh** — Run one phase (1–5) for an intent: reads .cursor/commands/ship.md and .cursor/rules; builds prompt; calls LLM; writes to workflow-state; stops after phase 2 and 5 with approval instructions. Uses existing workflow_state.sh for flat/per-intent dirs.
- **scripts/headless/call-llm.js** — Node helper: stdin or --prompt → OpenAI or Anthropic API → stdout. No new dependencies (fetch + env).
- **scripts/headless/README.md** — Pointer to docs.
- **package.json** — `pnpm headless-run-phase` → run-phase.sh.
- **scripts/test-headless.sh** — Smoke test: no API key message, invalid phase rejection.
- **README.md** — Headless / VS Code paragraph with links.

## Validation

- `bash scripts/test-headless.sh` — passed.
- `pnpm test` — passed.

Resolves #65