### PR TITLE
fix: add dashboard-app to tsconfig.eslint.json in init templates (Resolves #99)

### DIFF
--- a/cli/src/utils/stack-files.js
+++ b/cli/src/utils/stack-files.js
@@ -97,7 +97,7 @@ export function createTypeScriptNodeFiles(projectPath, projectName, description,
   // Create tsconfig.eslint.json
   const tsconfigEslint = {
     extends: './tsconfig.json',
-    include: ['src/**/*.ts', 'tests/**/*.ts', 'scripts/**/*.ts', '*.config.ts'],
+    include: ['src/**/*.ts', 'tests/**/*.ts', 'scripts/**/*.ts', 'dashboard-app/**/*.ts', '*.config.ts'],
     exclude: ['node_modules', 'dist']
   };
 

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -826,6 +826,7 @@ EOF
     "src/**/*.ts",
     "tests/**/*.ts",
     "scripts/**/*.ts",
+    "dashboard-app/**/*.ts",
     "*.config.ts"
   ],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Resolves #99

## Summary

ESLint was failing on freshly initialized projects because `dashboard-app/vite.config.ts` (and other dashboard-app files) were not included in the generated `tsconfig.eslint.json`. The TypeScript ESLint parser requires all linted files to be in the project.

## Changes

- **scripts/init-project.sh:** Added `dashboard-app/**/*.ts` to the include array in the tsconfig.eslint.json template
- **cli/src/utils/stack-files.js:** Same fix for the create-shipit-app scaffolding path

## Validation

- `./scripts/init-project.sh shipit-test` → generated project has correct tsconfig.eslint.json
- `pnpm lint` in generated project → passes
- `pnpm test`, `pnpm lint`, `pnpm typecheck` in framework repo → all pass